### PR TITLE
Retain active-state (closes #201)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ import pathlib
 
 import setuptools
 
-_REPO_URL = "https://github.com/avrovulcanxh607/systemctl-mqtt"
+_REPO_URL = "https://github.com/fphammerle/systemctl-mqtt"
 
 setuptools.setup(
     name="systemctl-mqtt",

--- a/systemctl_mqtt/__init__.py
+++ b/systemctl_mqtt/__init__.py
@@ -15,8 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-print("nathan's version 3")
-
 import abc
 import argparse
 import asyncio


### PR DESCRIPTION
Monitored unit active-states are now retained. To try & prevent invalid data getting "stuck" in the broker, we publish "unknown" as the status to every monitored unit on shutdown.