### PR TITLE
Bump jeepney

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Added
+- support jeepney v0.9
 
 ## [1.1.0] - 2025-01-19
 ### Added

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -26,11 +26,11 @@
         },
         "jeepney": {
             "hashes": [
-                "sha256:5efe48d255973902f6badc3ce55e2aa6c5c3b3bc642059ef3a91247bcfcc5806",
-                "sha256:c0a454ad016ca575060802ee4d590dd912e35c122fa04e70306de3d076cce755"
+                "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683",
+                "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.8.0"
+            "version": "==0.9.0"
         },
         "paho-mqtt": {
             "hashes": [

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setuptools.setup(
     # > implementing the protocol, and integrations for both blocking I/O and
     # > for different asynchronous frameworks.
     # https://web.archive.org/web/20241206000411/https://www.freedesktop.org/wiki/Software/DBusBindings/
-    install_requires=["aiomqtt>=2,<3", "jeepney>=0.8,<0.9"],
+    install_requires=["aiomqtt>=2,<3", "jeepney>=0.9,<1.0"],
     setup_requires=["setuptools_scm"],
     tests_require=["pytest"],
 )

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setuptools.setup(
     # > implementing the protocol, and integrations for both blocking I/O and
     # > for different asynchronous frameworks.
     # https://web.archive.org/web/20241206000411/https://www.freedesktop.org/wiki/Software/DBusBindings/
-    install_requires=["aiomqtt>=2,<3", "jeepney>=0.9,<1.0"],
+    install_requires=["aiomqtt>=2,<3", "jeepney>=0.8,<1.0"],
     setup_requires=["setuptools_scm"],
     tests_require=["pytest"],
 )

--- a/tests/test_dbus.py
+++ b/tests/test_dbus.py
@@ -426,7 +426,7 @@ async def test__dbus_signal_loop_unit() -> None:
             dbus_router=dbus_router_mock,
             bus_proxy=bus_proxy_mock,
             unit_name="foo.service",
-            unit_path="/org/freedesktop/systemd1/unit/whatever.service",
+            unit_path="/org/freedesktop/systemd1/unit/whatever_2eservice",
         )
     )
 


### PR DESCRIPTION
This is motivated by NixOS pulling in the latest jeepney (0.9.0) and it's cleaner if I don't have to override that with an older version. :-P

I don't see anything from the breaking changes being used