### PR TITLE
Retain messages

### DIFF
--- a/systemctl_mqtt/__init__.py
+++ b/systemctl_mqtt/__init__.py
@@ -146,7 +146,7 @@ class _State:
         # pylint: disable=protected-access
         payload = systemctl_mqtt._mqtt.encode_bool(active)
         _LOGGER.info("publishing %r on %s", payload, topic)
-        await mqtt_client.publish(topic=topic, payload=payload, retain=False)
+        await mqtt_client.publish(topic=topic, payload=payload, retain=True)
 
     async def preparing_for_shutdown_handler(
         self, active: bool, mqtt_client: aiomqtt.Client
@@ -259,7 +259,7 @@ class _State:
 
         _LOGGER.debug("publishing home assistant config on %s", discovery_topic)
         await mqtt_client.publish(
-            topic=discovery_topic, payload=json.dumps(config), retain=False
+            topic=discovery_topic, payload=json.dumps(config), retain=True
         )
 
 
@@ -457,7 +457,9 @@ async def _dbus_signal_loop_unit(  # pylint: disable=too-many-arguments
         unit_name=unit_name
     )
     ((_, last_active_state),) = await unit_proxy.Get(property_name="ActiveState")
-    await mqtt_client.publish(topic=active_state_topic, payload=last_active_state)
+    await mqtt_client.publish(
+        topic=active_state_topic, payload=last_active_state, retain=True
+    )
     with dbus_router.filter(unit_properties_changed_match_rule) as queue:
         while True:
             await queue.get()
@@ -466,7 +468,7 @@ async def _dbus_signal_loop_unit(  # pylint: disable=too-many-arguments
             )
             if current_active_state != last_active_state:
                 await mqtt_client.publish(
-                    topic=active_state_topic, payload=current_active_state
+                    topic=active_state_topic, payload=current_active_state, retain=True
                 )
                 last_active_state = current_active_state
             queue.task_done()


### PR DESCRIPTION
State wasn't showing up correctly in Home Assistant due to unretained messages. If this ran first, then HA, HA would never get state messages, until/unless service state changed. If HA ran first, then this, HA would get the discovery message, but wouldn't subscribe in time to get service states, and so wouldn't get those until/unless the service state changed (again).